### PR TITLE
Update research page with EigenOS text

### DIFF
--- a/src/app/research/page.tsx
+++ b/src/app/research/page.tsx
@@ -4,55 +4,44 @@ export default function ResearchPage() {
     <div className="flex bg-black text-white h-screen">
 
       <main className="flex-1 overflow-y-auto p-10 space-y-16">
-        {/* Section 1: Intro */}
-        <section className="max-w-4xl mx-auto">
-          <h1 className="text-4xl font-bold mb-4">Quantum Transformer Research</h1>
+        {/* Section 1: Kernel Intro */}
+        <section className="max-w-4xl mx-auto space-y-4">
+          <h1 className="text-4xl font-bold">Quantum OS Kernel Research</h1>
           <p className="text-gray-300 text-lg">
-            VonX is building the world’s first Quantum Transformer model. Our research combines classical language modeling with quantum circuits like variational QNNs and quantum entanglement attention.
+            VonX is building EigenOS — the first quantum-native operating system kernel. It orchestrates hybrid quantum-classical computation across simulators and real QPUs with deterministic scheduling, memory-safe execution, and real-time control.
+          </p>
+          <p className="text-gray-300 text-lg">
+            Explore a mini, simple and working prototype at <a href="https://haulvisor.vercel.app" className="underline">haulvisor.vercel.app</a>.
+          </p>
+          <p className="text-gray-300 text-lg">
+            EigenOS treats quantum processes with the same rigor as classical OSes treat processes, threads, and memory. It fills the essential system-level gap required to unlock scalable, production-grade quantum AI.
           </p>
         </section>
 
-        {/* Section 2: Architecture */}
-        <section className="max-w-4xl mx-auto">
-          <h2 className="text-2xl font-semibold mb-3">Architecture Overview</h2>
-          <ul className="list-disc text-gray-400 pl-6 space-y-1">
-            <li>Classical token embedding → angle/amplitude encoded into qubits</li>
-            <li>Quantum attention circuit using entanglement + QFT</li>
-            <li>Quantum FFN built on variational circuits</li>
-            <li>Final measurement collapsed to classical logits</li>
-          </ul>
-        </section>
-
-        {/* Section 3: Qiskit Circuit Diagram (Placeholder) */}
-        <section className="max-w-4xl mx-auto">
-          <h2 className="text-2xl font-semibold mb-3">Quantum Circuit Sketch</h2>
-          <div className="rounded-xl bg-zinc-900 p-6 text-center text-gray-400 border border-zinc-700">
-            (Quantum Attention + Feedforward Circuits built with Qiskit & PennyLane)
-          </div>
-        </section>
-
-        {/* Section 4: Use Cases */}
-        <section className="max-w-4xl mx-auto">
-          <h2 className="text-2xl font-semibold mb-3">Why Quantum?</h2>
-          <p className="text-gray-300">
-            Quantum attention mechanisms may enable:
+        {/* Section 2: Hybrid Models */}
+        <section className="max-w-4xl mx-auto space-y-4">
+          <h2 className="text-3xl font-bold">Focus on Quantum–Classical AI Models</h2>
+          <p className="text-gray-300 text-lg">
+            Our work extends far beyond infrastructure. We’re developing models that leverage EigenOS to run hybrid architectures efficiently:
           </p>
-          <ul className="list-disc text-gray-400 pl-6 mt-2 space-y-1">
-            <li>Better symbolic reasoning</li>
-            <li>Native modeling of quantum data (chemistry, physics)</li>
-            <li>Compact expressivity with fewer parameters</li>
-          </ul>
+          <p className="text-gray-300 text-lg">
+            <strong>QuantumGPTMini</strong>, a token-to-qubit transformer using entanglement-based attention and variational feedforward networks.
+          </p>
+          <p className="text-gray-300 text-lg">
+            Integration of EigenOS primitives enables low-latency hybrid inference, streaming responses from CPU→QPU→CPU.
+          </p>
+          <p className="text-gray-300 text-lg">
+            These models prove EigenOS’s worth and enable rich experiments in hybrid AI.
+          </p>
+          <p className="text-gray-300 text-lg">
+            A recent study by Amire Ramazan—“QuantumGPTMini: A Hybrid Quantum-Classical Transformer for Enhanced NLP”—documents the architecture and benchmark performance. Published April 28, 2025, it outlines how QuantumGPTMini uses about one million classical parameters alongside lightweight quantum circuits. <a href="https://www.authorea.com/users/918341/articles/1290843-quantumgptmini-a-hybrid-quantum-classical-transformer-for-enhanced-nlp" className="underline">Read the paper</a>.
+          </p>
         </section>
 
-        {/* Section 5: Research Roadmap */}
+        {/* Section 3: Research Roadmap */}
         <section className="max-w-4xl mx-auto">
           <h2 className="text-2xl font-semibold mb-3">Roadmap</h2>
-          <ul className="list-decimal text-gray-400 pl-6 space-y-1">
-            <li>Phase 1 — Build circuit-based transformer blocks (done)</li>
-            <li>Phase 2 — Train on wiki dataset on A100 (done)</li>
-            <li>Phase 3 — Implement streaming, QPU evals (ongoing)</li>
-            <li>Phase 4 — Publish paper & preprint (coming)</li>
-          </ul>
+          <p className="text-gray-300 text-lg">Roadmap details coming soon.</p>
         </section>
       </main>
     </div>


### PR DESCRIPTION
## Summary
- overhaul research page to describe EigenOS kernel prototype
- add section about hybrid models using EigenOS
- remove outdated phase roadmap

## Testing
- `npm run lint` *(fails: react/no-unescaped-entities, @typescript-eslint/no-explicit-any)*

------
https://chatgpt.com/codex/tasks/task_e_6856b77a9484832eb2fc9d31695fd3ce